### PR TITLE
bug_fix_webpacker

### DIFF
--- a/app/javascript/packs/slide-show.js
+++ b/app/javascript/packs/slide-show.js
@@ -1,4 +1,4 @@
-const images = ["/public/images/visual-1.jpg", "/public/images/visual-2.jpg", "/public/images/visual-3.jpg"]
+const images = ["images/visual-1.jpg", "images/visual-2.jpg", "images/visual-3.jpg"]
 
 let num = -1
 
@@ -14,4 +14,4 @@ function slideShow_timer(){
   
 }
 
-setInterval(slideShow_timer, 1000);
+setInterval(slideShow_timer, 5000);

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,3 +1,4 @@
+= javascript_pack_tag 'slide-show'
 = render "shared/header"
 = render "shared/nav"
 = render "shared/main"


### PR DESCRIPTION
# What
webpackerがslide-show.jsを読み込みで機ないエラーを削除
javascript/packs配下にJSファイルを設置
# Why
エラー解消
