### PR TITLE
グループテーブルの修正

### DIFF
--- a/db/migrate/20200823104446_rename_profile_avatar_column_to_groups.rb
+++ b/db/migrate/20200823104446_rename_profile_avatar_column_to_groups.rb
@@ -1,5 +1,0 @@
-class RenameProfileAvatarColumnToGroups < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :groups, :profile_avatar, :group_avatar
-  end
-end


### PR DESCRIPTION
# What
groupsテーブルの修正
# Why
groupsテーブルのgroup_avatarカラムを、開発当初profile_avatarにしていた。
開発の都合上rename_columnを用いて修正したが、本番環境への影響を考慮し
修正した。